### PR TITLE
Update GlobalErrorController.java

### DIFF
--- a/wyait-manage-1.2.0/src/main/java/com/wyait/manage/web/error/GlobalErrorController.java
+++ b/wyait-manage-1.2.0/src/main/java/com/wyait/manage/web/error/GlobalErrorController.java
@@ -115,16 +115,16 @@ public class GlobalErrorController extends AbstractErrorController {
 	private ExceptionEnum getMessage(HttpStatus httpStatus) {
 		if (httpStatus.is4xxClientError()) {
 			// 4开头的错误状态码
-			if ("400".equals(httpStatus.BAD_REQUEST)) {
+			if (httpStatus == httpStatus.BAD_REQUEST) {
 				return ExceptionEnum.BAD_REQUEST;
-			} else if ("403".equals(httpStatus.FORBIDDEN)) {
+			} else if (httpStatus == httpStatus.FORBIDDEN) {
 				return ExceptionEnum.BAD_REQUEST;
-			} else if ("404".equals(httpStatus.NOT_FOUND)) {
+			} else if (httpStatus == httpStatus.NOT_FOUND) {
 				return ExceptionEnum.NOT_FOUND;
 			}
 		} else if (httpStatus.is5xxServerError()) {
 			// 5开头的错误状态码
-			if ("500".equals(httpStatus.INTERNAL_SERVER_ERROR)) {
+			if (httpStatus == httpStatus.INTERNAL_SERVER_ERROR) {
 				return ExceptionEnum.SERVER_EPT;
 			}
 		}


### PR DESCRIPTION
出现异常时总是返回"未知错误“，原因是getMessage方法犯了一个非常小儿科的错误！将字符串错误码和枚举类型作equalse,结果必然是false,而且并没有使用到参数